### PR TITLE
Using Header authentication

### DIFF
--- a/addon/adapters/contentful.js
+++ b/addon/adapters/contentful.js
@@ -172,7 +172,7 @@ export default DS.Adapter.extend({
     return fetch(`https://${api}.contentful.com/spaces/${space}/${type}/${this._serializeQueryParams(data)}`, {
       headers: {
         'Accept': 'application/json; charset=utf-8',
-        'Authorization': 'Bearer ' + accessToken
+        'Authorization': `Bearer ${accessToken}`
       }
     }).then((response) => {
       return response.json();

--- a/addon/adapters/contentful.js
+++ b/addon/adapters/contentful.js
@@ -169,12 +169,10 @@ export default DS.Adapter.extend({
       space
     } = this._getConfig();
 
-    Object.assign(data, {
-      'access_token': accessToken
-    });
     return fetch(`https://${api}.contentful.com/spaces/${space}/${type}/${this._serializeQueryParams(data)}`, {
       headers: {
-        'Accept': 'application/json; charset=utf-8'
+        'Accept': 'application/json; charset=utf-8',
+        'Authorization': 'Bearer ' + accessToken
       }
     }).then((response) => {
       return response.json();


### PR DESCRIPTION
- Removing `Object.assign` since it is unsupported in Internet Explorer