### PR TITLE
`queryRecord` only asks for one record from the API

### DIFF
--- a/addon/adapters/contentful.js
+++ b/addon/adapters/contentful.js
@@ -163,6 +163,8 @@ export default DS.Adapter.extend({
   queryRecord(store, type, query) {
     query = query || {};
     query['content_type'] = this.contentTypeParam(type.modelName);
+    query['limit'] = 1;
+    query['skip'] = 0;
     return this._getContent('entries', query);
   },
 

--- a/tests/unit/adapters/contentful-test.js
+++ b/tests/unit/adapters/contentful-test.js
@@ -1,0 +1,63 @@
+import { test, only, moduleForModel } from 'ember-qunit';
+import ContentfulModel from 'ember-data-contentful/models/contentful';
+import ContentfulAdapter from 'ember-data-contentful/adapters/contentful';
+
+import attr from 'ember-data/attr';
+
+var Post, PostAdapter;
+
+moduleForModel('contentful', 'Unit | Adapter | contentful', {
+  beforeEach() {
+
+    Post = ContentfulModel.extend({
+      title: attr('string'),
+    });
+
+    this.registry.register('model:post', Post);
+  }
+});
+
+test('queryRecord calls _getContent with correct parameters when query is empty', function(assert) {
+
+  let actualParams = null;
+
+  const ApplicationAdapter = ContentfulAdapter.extend({
+    _getContent(type, params) {
+      actualParams = params;
+      this._super(...arguments);
+    }
+  });
+  this.registry.register('adapter:application', ApplicationAdapter);
+
+  this.store().queryRecord('post', { });
+
+  assert.deepEqual(actualParams, {
+    content_type: 'post',
+    skip: 0,
+    limit: 1
+  });
+
+});
+
+test('queryRecord calls _getContent with correct parameters', function(assert) {
+
+  let actualParams = null;
+
+  const ApplicationAdapter = ContentfulAdapter.extend({
+    _getContent(type, params) {
+      actualParams = params;
+      this._super(...arguments);
+    }
+  });
+  this.registry.register('adapter:application', ApplicationAdapter);
+
+  this.store().queryRecord('post', { order: 'fields.title' });
+
+  assert.deepEqual(actualParams, {
+    content_type: 'post',
+    order: 'fields.title',
+    skip: 0,
+    limit: 1
+  });
+
+});


### PR DESCRIPTION
- Added spec for `queryRecord` params