### PR TITLE
Handling case where model has no includes

### DIFF
--- a/addon/serializers/contentful.js
+++ b/addon/serializers/contentful.js
@@ -185,7 +185,7 @@ export default DS.JSONSerializer.extend({
   },
 
   _extractIncludes(store, payload) {
-    if(payload && payload.hasOwnProperty('includes')) {
+    if(payload && payload.hasOwnProperty('includes') && typeof payload.includes !== "undefined") {
       let entries = new Array();
       let assets = new Array();
 

--- a/tests/unit/serializers/contentful-test.js
+++ b/tests/unit/serializers/contentful-test.js
@@ -302,9 +302,39 @@ test('normalizeQueryRecordResponse with an item w/o includes', function(assert) 
     "skip": 0,
     "limit": 1,
     "items": [
-      post
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "foobar"
+            }
+          },
+          "id": "1",
+          "type": "Entry",
+          "createdAt": "2017-02-23T21:40:37.180Z",
+          "updatedAt": "2017-02-27T21:24:26.007Z",
+          "revision": 3,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "post"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "title": "Example Post"
+        }
+      }
     ]
   };
+
+  Post = ContentfulModel.extend({
+    title: attr('string')
+  });
 
   let serializer = this.store().serializerFor('post');
 
@@ -329,15 +359,7 @@ test('normalizeQueryRecordResponse with an item w/o includes', function(assert) 
 
   assert.equal(documentHash.data.id, post.sys.id);
   assert.equal(documentHash.data.type, "post");
-  assert.deepEqual(documentHash.data.relationships, {
-    "image": {
-      "data": {
-        "id": '2',
-        "type": 'contentful-asset'
-      }
-    }
-  });
-
+  assert.deepEqual(documentHash.data.relationships, {});
   assert.equal(documentHash.included.length, 0);
 });
 
@@ -441,9 +463,39 @@ test('normalizeQueryResponse with an item w/o includes', function(assert) {
     "skip": 0,
     "limit": 1,
     "items": [
-      post
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "foobar"
+            }
+          },
+          "id": "1",
+          "type": "Entry",
+          "createdAt": "2017-02-23T21:40:37.180Z",
+          "updatedAt": "2017-02-27T21:24:26.007Z",
+          "revision": 3,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "post"
+            }
+          },
+          "locale": "en-US"
+        },
+        "fields": {
+          "title": "Example Post"
+        }
+      }
     ]
   };
+
+  Post = ContentfulModel.extend({
+    title: attr('string')
+  });
 
   let serializer = this.store().serializerFor('post');
 
@@ -472,14 +524,7 @@ test('normalizeQueryResponse with an item w/o includes', function(assert) {
 
   assert.equal(postData.id, post.sys.id);
   assert.equal(postData.type, "post");
-  assert.deepEqual(postData.relationships, {
-    "image": {
-      "data": {
-        "id": '2',
-        "type": 'contentful-asset'
-      }
-    }
-  });
+  assert.deepEqual(postData.relationships, {});
 
   // Includes
   assert.equal(documentHash.included.length, 0);

--- a/tests/unit/serializers/contentful-test.js
+++ b/tests/unit/serializers/contentful-test.js
@@ -291,6 +291,56 @@ test('normalizeQueryRecordResponse with an item with includes', function(assert)
   assert.deepEqual(asset.relationships, {});
 });
 
+test('normalizeQueryRecordResponse with an item w/o includes', function(assert) {
+
+  let id = '';
+  let payload = {
+    "sys": {
+      "type": "Array"
+    },
+    "total": 1,
+    "skip": 0,
+    "limit": 1,
+    "items": [
+      post
+    ]
+  };
+
+  let serializer = this.store().serializerFor('post');
+
+  let documentHash = serializer.normalizeQueryRecordResponse(
+    this.store(),
+    Post,
+    payload,
+    id,
+    'queryRecord'
+  );
+
+  assert.equal(documentHash.data.attributes.contentType, "post");
+  assert.equal(documentHash.data.attributes.title, post.fields.title);
+
+  let expectedCreatedAt = new Date(documentHash.data.attributes.createdAt);
+  let actualCreatedAt = new Date(post.sys.createdAt);
+  assert.equal(expectedCreatedAt.toString(), actualCreatedAt.toString());
+
+  let expectedUpdatedAt = new Date(documentHash.data.attributes.updatedAt);
+  let actualUpdatedAt = new Date(post.sys.updatedAt);
+  assert.equal(expectedUpdatedAt.toString(), actualUpdatedAt.toString());
+
+  assert.equal(documentHash.data.id, post.sys.id);
+  assert.equal(documentHash.data.type, "post");
+  assert.deepEqual(documentHash.data.relationships, {
+    "image": {
+      "data": {
+        "id": '2',
+        "type": 'contentful-asset'
+      }
+    }
+  });
+
+  assert.equal(documentHash.included.length, 0);
+});
+
 test('normalizeQueryResponse with an item with includes', function(assert) {
 
   let id = '';
@@ -374,6 +424,65 @@ test('normalizeQueryResponse with an item with includes', function(assert) {
   assert.equal(expectedAssetUpdatedAt.toString(), actualAssetUpdatedAt.toString());
 
   assert.deepEqual(asset.relationships, {});
+
+  // Meta
+  let meta = serializer.extractMeta(this.store(), Post, payload);
+  assert.deepEqual(documentHash.meta, meta);
+});
+
+test('normalizeQueryResponse with an item w/o includes', function(assert) {
+
+  let id = '';
+  let payload = {
+    "sys": {
+      "type": "Array"
+    },
+    "total": 1,
+    "skip": 0,
+    "limit": 1,
+    "items": [
+      post
+    ]
+  };
+
+  let serializer = this.store().serializerFor('post');
+
+  let documentHash = serializer.normalizeQueryResponse(
+    this.store(),
+    Post,
+    payload,
+    id,
+    'queryRecord'
+  );
+
+  // Items (Posts)
+  assert.equal(documentHash.data.length, 1);
+
+  let postData = documentHash.data[0];
+  assert.equal(postData.attributes.contentType, "post");
+  assert.equal(postData.attributes.title, post.fields.title);
+
+  let expectedCreatedAt = new Date(postData.attributes.createdAt);
+  let actualCreatedAt = new Date(post.sys.createdAt);
+  assert.equal(expectedCreatedAt.toString(), actualCreatedAt.toString());
+
+  let expectedUpdatedAt = new Date(postData.attributes.updatedAt);
+  let actualUpdatedAt = new Date(post.sys.updatedAt);
+  assert.equal(expectedUpdatedAt.toString(), actualUpdatedAt.toString());
+
+  assert.equal(postData.id, post.sys.id);
+  assert.equal(postData.type, "post");
+  assert.deepEqual(postData.relationships, {
+    "image": {
+      "data": {
+        "id": '2',
+        "type": 'contentful-asset'
+      }
+    }
+  });
+
+  // Includes
+  assert.equal(documentHash.included.length, 0);
 
   // Meta
   let meta = serializer.extractMeta(this.store(), Post, payload);


### PR DESCRIPTION
If you have a model that doesn't have any relationships, then there will not be an includes part of the payload. The `includes` property will be defined on the object but it will be set to `undefined`. This adds a check for that.