### PR TITLE
Add support for an optional environment parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ contentful: {
   space: 'YOUR-CONTENTFUL-SPACE',
   accessToken: 'YOUR-CONTENTFUL-ACCESS-TOKEN',
   previewAccessToken: 'YOUR-CONTENTFUL-PREVIEW-ACCESS-TOKEN',
-  usePreviewApi: false
+  usePreviewApi: false,
+  environment: 'master' // Optional, defaults to 'master'
 }
 ```
 

--- a/addon/adapters/contentful.js
+++ b/addon/adapters/contentful.js
@@ -182,10 +182,11 @@ export default DS.Adapter.extend({
     let {
       accessToken,
       api,
-      space
+      space,
+      environment
     } = this._getConfig();
 
-    return fetch(`https://${api}.contentful.com/spaces/${space}/${type}/${this._serializeQueryParams(data)}`, {
+    return fetch(`https://${api}.contentful.com/spaces/${space}/environments/${environment}/${type}/${this._serializeQueryParams(data)}`, {
       headers: {
         'Accept': 'application/json; charset=utf-8',
         'Authorization': `Bearer ${accessToken}`
@@ -239,6 +240,7 @@ export default DS.Adapter.extend({
     let api = 'cdn';
     let space = config.contentful ? config.contentful.space : config.contentfulSpace;
     let previewAccessToken = config.contentful ? config.contentful.previewAccessToken : config.contentfulPreviewAccessToken;
+    let environment = (config.contentful && config.contentful.environment) || 'master';
 
     if (config.contentful.usePreviewApi || config.contentfulUsePreviewApi) {
       if (!previewAccessToken) {
@@ -259,7 +261,8 @@ export default DS.Adapter.extend({
     return {
       accessToken,
       api,
-      space
+      space,
+      environment
     };
   }
 });


### PR DESCRIPTION
Hello!

One thing that contentful supports now is the ability to query different environments. Currently `ember-data-contentful` makes calls to the default address for a space, which is always `master` environment. 

See "Access content in an environment" section of [this page](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/environments) for documentation.

This PR updates the shape of the URL that's called to include an environment parameter, so a user can optional set an environment other than `master`.